### PR TITLE
[library] Add xml mapping informations

### DIFF
--- a/ecore.ecore
+++ b/ecore.ecore
@@ -267,6 +267,7 @@
       </eAnnotations>
       <eParameters name="object" eType="#//EJavaObject"/>
     </eOperations>
+    <eStructuralFeatures xsi:type="ecore:EAttribute" name="instanceTypeName" eType="#//EString"/>
     <eStructuralFeatures xsi:type="ecore:EAttribute" name="instanceClass">
       <eGenericType eClassifier="#//EJavaClass">
         <eTypeArguments/>
@@ -765,6 +766,9 @@
     <eAnnotations source="http://net.masagroup/soft/2018/GenCpp">
       <details key="instanceTypeName" value="double"/>
     </eAnnotations>
+    <eAnnotations source="http://net.masagroup/soft/2019/GenGo">
+      <details key="instanceTypeName" value="float64"/>
+    </eAnnotations>
   </eClassifiers>
   <eClassifiers xsi:type="ecore:EDataType" name="EBigInteger" instanceClassName="java.math.BigInteger">
     <eAnnotations source="http:///org/eclipse/emf/ecore/util/ExtendedMetaData">
@@ -773,12 +777,18 @@
     <eAnnotations source="http://net.masagroup/soft/2018/GenCpp">
       <details key="instanceTypeName" value="int"/>
     </eAnnotations>
+    <eAnnotations source="http://net.masagroup/soft/2019/GenGo">
+      <details key="instanceTypeName" value="int"/>
+    </eAnnotations>
   </eClassifiers>
   <eClassifiers xsi:type="ecore:EDataType" name="EBoolean" instanceClassName="boolean">
     <eAnnotations source="http:///org/eclipse/emf/ecore/util/ExtendedMetaData">
       <details key="baseType" value="http://www.w3.org/2001/XMLSchema#boolean"/>
     </eAnnotations>
     <eAnnotations source="http://net.masagroup/soft/2018/GenCpp">
+      <details key="instanceTypeName" value="bool"/>
+    </eAnnotations>
+    <eAnnotations source="http://net.masagroup/soft/2019/GenGo">
       <details key="instanceTypeName" value="bool"/>
     </eAnnotations>
   </eClassifiers>
@@ -790,6 +800,9 @@
     <eAnnotations source="http://net.masagroup/soft/2018/GenCpp">
       <details key="instanceTypeName" value="bool"/>
     </eAnnotations>
+    <eAnnotations source="http://net.masagroup/soft/2019/GenGo">
+      <details key="instanceTypeName" value="bool"/>
+    </eAnnotations>
   </eClassifiers>
   <eClassifiers xsi:type="ecore:EDataType" name="EByte" instanceClassName="byte">
     <eAnnotations source="http:///org/eclipse/emf/ecore/util/ExtendedMetaData">
@@ -798,6 +811,9 @@
     <eAnnotations source="http://net.masagroup/soft/2018/GenCpp">
       <details key="instanceTypeName" value="char"/>
     </eAnnotations>
+    <eAnnotations source="http://net.masagroup/soft/2019/GenGo">
+      <details key="instanceTypeName" value="byte"/>
+    </eAnnotations>
   </eClassifiers>
   <eClassifiers xsi:type="ecore:EDataType" name="EByteArray" instanceClassName="byte[]">
     <eAnnotations source="http:///org/eclipse/emf/ecore/util/ExtendedMetaData">
@@ -805,6 +821,9 @@
     </eAnnotations>
     <eAnnotations source="http://net.masagroup/soft/2018/GenCpp">
       <details key="instanceTypeName" value="char[]"/>
+    </eAnnotations>
+    <eAnnotations source="http://net.masagroup/soft/2019/GenGo">
+      <details key="instanceTypeName" value="[]byte"/>
     </eAnnotations>
   </eClassifiers>
   <eClassifiers xsi:type="ecore:EDataType" name="EByteObject" instanceClassName="java.lang.Byte">
@@ -815,10 +834,16 @@
     <eAnnotations source="http://net.masagroup/soft/2018/GenCpp">
       <details key="instanceTypeName" value="char"/>
     </eAnnotations>
+    <eAnnotations source="http://net.masagroup/soft/2019/GenGo">
+      <details key="instanceTypeName" value="byte"/>
+    </eAnnotations>
   </eClassifiers>
   <eClassifiers xsi:type="ecore:EDataType" name="EChar" instanceClassName="char">
     <eAnnotations source="http://net.masagroup/soft/2018/GenCpp">
       <details key="instanceTypeName" value="char"/>
+    </eAnnotations>
+    <eAnnotations source="http://net.masagroup/soft/2019/GenGo">
+      <details key="instanceTypeName" value="byte"/>
     </eAnnotations>
   </eClassifiers>
   <eClassifiers xsi:type="ecore:EDataType" name="ECharacterObject" instanceClassName="java.lang.Character">
@@ -829,21 +854,34 @@
     <eAnnotations source="http://net.masagroup/soft/2018/GenCpp">
       <details key="instanceTypeName" value="char"/>
     </eAnnotations>
+    <eAnnotations source="http://net.masagroup/soft/2019/GenGo">
+      <details key="instanceTypeName" value="byte"/>
+    </eAnnotations>
   </eClassifiers>
   <eClassifiers xsi:type="ecore:EDataType" name="EDate" instanceClassName="java.util.Date">
     <eAnnotations source="http://net.masagroup/soft/2018/GenCpp">
       <details key="instanceTypeName" value="std::time_t"/>
       <details key="include" value="&lt;ctime>"/>
     </eAnnotations>
+    <eAnnotations source="http://net.masagroup/soft/2019/GenGo">
+      <details key="instanceTypeName" value="time.Time"/>
+    </eAnnotations>
   </eClassifiers>
   <eClassifiers xsi:type="ecore:EDataType" name="EDiagnosticChain" instanceClassName="org.eclipse.emf.common.util.DiagnosticChain"
-      serializable="false"/>
+      serializable="false">
+    <eAnnotations source="http://net.masagroup/soft/2019/GenGo">
+      <details key="instanceTypeName" value="ecore.EDiagnosticChain"/>
+    </eAnnotations>
+  </eClassifiers>
   <eClassifiers xsi:type="ecore:EDataType" name="EDouble" instanceClassName="double">
     <eAnnotations source="http:///org/eclipse/emf/ecore/util/ExtendedMetaData">
       <details key="baseType" value="http://www.w3.org/2001/XMLSchema#double"/>
     </eAnnotations>
     <eAnnotations source="http://net.masagroup/soft/2018/GenCpp">
       <details key="instanceTypeName" value="double"/>
+    </eAnnotations>
+    <eAnnotations source="http://net.masagroup/soft/2019/GenGo">
+      <details key="instanceTypeName" value="float64"/>
     </eAnnotations>
   </eClassifiers>
   <eClassifiers xsi:type="ecore:EDataType" name="EDoubleObject" instanceClassName="java.lang.Double">
@@ -853,6 +891,9 @@
     </eAnnotations>
     <eAnnotations source="http://net.masagroup/soft/2018/GenCpp">
       <details key="instanceTypeName" value="double"/>
+    </eAnnotations>
+    <eAnnotations source="http://net.masagroup/soft/2019/GenGo">
+      <details key="instanceTypeName" value="float64"/>
     </eAnnotations>
   </eClassifiers>
   <eClassifiers xsi:type="ecore:EDataType" name="EEList" instanceClassName="org.eclipse.emf.common.util.EList"
@@ -876,6 +917,9 @@
     <eAnnotations source="http://net.masagroup/soft/2018/GenCpp">
       <details key="instanceTypeName" value="float"/>
     </eAnnotations>
+    <eAnnotations source="http://net.masagroup/soft/2019/GenGo">
+      <details key="instanceTypeName" value="float64"/>
+    </eAnnotations>
   </eClassifiers>
   <eClassifiers xsi:type="ecore:EDataType" name="EFloatObject" instanceClassName="java.lang.Float">
     <eAnnotations source="http:///org/eclipse/emf/ecore/util/ExtendedMetaData">
@@ -885,12 +929,18 @@
     <eAnnotations source="http://net.masagroup/soft/2018/GenCpp">
       <details key="instanceTypeName" value="float"/>
     </eAnnotations>
+    <eAnnotations source="http://net.masagroup/soft/2019/GenGo">
+      <details key="instanceTypeName" value="float64"/>
+    </eAnnotations>
   </eClassifiers>
   <eClassifiers xsi:type="ecore:EDataType" name="EInt" instanceClassName="int">
     <eAnnotations source="http:///org/eclipse/emf/ecore/util/ExtendedMetaData">
       <details key="baseType" value="http://www.w3.org/2001/XMLSchema#int"/>
     </eAnnotations>
     <eAnnotations source="http://net.masagroup/soft/2018/GenCpp">
+      <details key="instanceTypeName" value="int"/>
+    </eAnnotations>
+    <eAnnotations source="http://net.masagroup/soft/2019/GenGo">
       <details key="instanceTypeName" value="int"/>
     </eAnnotations>
   </eClassifiers>
@@ -902,11 +952,17 @@
     <eAnnotations source="http://net.masagroup/soft/2018/GenCpp">
       <details key="instanceTypeName" value="int"/>
     </eAnnotations>
+    <eAnnotations source="http://net.masagroup/soft/2019/GenGo">
+      <details key="instanceTypeName" value="int"/>
+    </eAnnotations>
   </eClassifiers>
   <eClassifiers xsi:type="ecore:EDataType" name="EJavaClass" instanceClassName="java.lang.Class">
     <eAnnotations source="http://net.masagroup/soft/2018/GenCpp">
       <details key="instanceTypeName" value="const std::type_info*"/>
       <details key="include" value="&lt;typeinfo>"/>
+    </eAnnotations>
+    <eAnnotations source="http://net.masagroup/soft/2019/GenGo">
+      <details key="instanceTypeName" value="reflect.Type"/>
     </eAnnotations>
     <eTypeParameters name="T"/>
   </eClassifiers>
@@ -915,6 +971,9 @@
       <details key="instanceTypeName" value="ecore::Any"/>
       <details key="include" value="&quot;ecore/Any.hpp&quot;"/>
     </eAnnotations>
+    <eAnnotations source="http://net.masagroup/soft/2019/GenGo">
+      <details key="instanceTypeName" value="interface{}"/>
+    </eAnnotations>
   </eClassifiers>
   <eClassifiers xsi:type="ecore:EDataType" name="ELong" instanceClassName="long">
     <eAnnotations source="http:///org/eclipse/emf/ecore/util/ExtendedMetaData">
@@ -922,6 +981,9 @@
     </eAnnotations>
     <eAnnotations source="http://net.masagroup/soft/2018/GenCpp">
       <details key="instanceTypeName" value="long"/>
+    </eAnnotations>
+    <eAnnotations source="http://net.masagroup/soft/2019/GenGo">
+      <details key="instanceTypeName" value="int"/>
     </eAnnotations>
   </eClassifiers>
   <eClassifiers xsi:type="ecore:EDataType" name="ELongObject" instanceClassName="java.lang.Long">
@@ -932,12 +994,18 @@
     <eAnnotations source="http://net.masagroup/soft/2018/GenCpp">
       <details key="instanceTypeName" value="long"/>
     </eAnnotations>
+    <eAnnotations source="http://net.masagroup/soft/2019/GenGo">
+      <details key="instanceTypeName" value="int"/>
+    </eAnnotations>
   </eClassifiers>
   <eClassifiers xsi:type="ecore:EDataType" name="EMap" instanceClassName="java.util.Map"
       serializable="false">
     <eAnnotations source="http://net.masagroup/soft/2018/GenCpp">
       <details key="instanceTypeName" value="std::map"/>
       <details key="include" value="&lt;map>"/>
+    </eAnnotations>
+    <eAnnotations source="http://net.masagroup/soft/2019/GenGo">
+      <details key="instanceTypeName" value="ecore.EMap"/>
     </eAnnotations>
     <eTypeParameters name="K"/>
     <eTypeParameters name="V"/>
@@ -948,15 +1016,25 @@
       <details key="instanceTypeName" value="std::shared_ptr&lt;ecore::EResource>"/>
       <details key="include" value="&quot;ecore/EResource.hpp&quot;"/>
     </eAnnotations>
+    <eAnnotations source="http://net.masagroup/soft/2019/GenGo">
+      <details key="instanceTypeName" value="ecore.EResource"/>
+    </eAnnotations>
   </eClassifiers>
   <eClassifiers xsi:type="ecore:EDataType" name="EResourceSet" instanceClassName="org.eclipse.emf.ecore.resource.ResourceSet"
-      serializable="false"/>
+      serializable="false">
+    <eAnnotations source="http://net.masagroup/soft/2019/GenGo">
+      <details key="instanceTypeName" value="ecore.EResourceSet"/>
+    </eAnnotations>
+  </eClassifiers>
   <eClassifiers xsi:type="ecore:EDataType" name="EShort" instanceClassName="short">
     <eAnnotations source="http:///org/eclipse/emf/ecore/util/ExtendedMetaData">
       <details key="baseType" value="http://www.w3.org/2001/XMLSchema#short"/>
     </eAnnotations>
     <eAnnotations source="http://net.masagroup/soft/2018/GenCpp">
       <details key="instanceTypeName" value="short"/>
+    </eAnnotations>
+    <eAnnotations source="http://net.masagroup/soft/2019/GenGo">
+      <details key="instanceTypeName" value="uint16"/>
     </eAnnotations>
   </eClassifiers>
   <eClassifiers xsi:type="ecore:EDataType" name="EShortObject" instanceClassName="java.lang.Short">
@@ -967,6 +1045,9 @@
     <eAnnotations source="http://net.masagroup/soft/2018/GenCpp">
       <details key="instanceTypeName" value="short"/>
     </eAnnotations>
+    <eAnnotations source="http://net.masagroup/soft/2019/GenGo">
+      <details key="instanceTypeName" value="uint16"/>
+    </eAnnotations>
   </eClassifiers>
   <eClassifiers xsi:type="ecore:EDataType" name="EString" instanceClassName="java.lang.String">
     <eAnnotations source="http:///org/eclipse/emf/ecore/util/ExtendedMetaData">
@@ -976,8 +1057,14 @@
       <details key="instanceTypeName" value="std::string"/>
       <details key="include" value="&lt;string>"/>
     </eAnnotations>
+    <eAnnotations source="http://net.masagroup/soft/2019/GenGo">
+      <details key="instanceTypeName" value="string"/>
+    </eAnnotations>
   </eClassifiers>
   <eClassifiers xsi:type="ecore:EClass" name="EStringToStringMapEntry" instanceClassName="java.util.Map$Entry">
+    <eAnnotations source="http://net.masagroup/soft/2019/GenGo">
+      <details key="instanceTypeName" value="ecore.EMapEntry"/>
+    </eAnnotations>
     <eStructuralFeatures xsi:type="ecore:EAttribute" name="key" eType="#//EString">
       <eAnnotations source="http://net.masagroup/soft/2019/GenGo">
         <details key="getterName" value="GetStringKey"/>
@@ -993,6 +1080,9 @@
   </eClassifiers>
   <eClassifiers xsi:type="ecore:EDataType" name="ETreeIterator" instanceClassName="org.eclipse.emf.common.util.TreeIterator"
       serializable="false">
+    <eAnnotations source="http://net.masagroup/soft/2019/GenGo">
+      <details key="instanceTypeName" value="ecore.EIterator"/>
+    </eAnnotations>
     <eTypeParameters name="E"/>
   </eClassifiers>
   <eClassifiers xsi:type="ecore:EClass" name="EGenericType">

--- a/ecore.ecore
+++ b/ecore.ecore
@@ -766,9 +766,6 @@
     <eAnnotations source="http://net.masagroup/soft/2018/GenCpp">
       <details key="instanceTypeName" value="double"/>
     </eAnnotations>
-    <eAnnotations source="http://net.masagroup/soft/2019/GenGo">
-      <details key="instanceTypeName" value="float64"/>
-    </eAnnotations>
   </eClassifiers>
   <eClassifiers xsi:type="ecore:EDataType" name="EBigInteger" instanceClassName="java.math.BigInteger">
     <eAnnotations source="http:///org/eclipse/emf/ecore/util/ExtendedMetaData">
@@ -777,18 +774,12 @@
     <eAnnotations source="http://net.masagroup/soft/2018/GenCpp">
       <details key="instanceTypeName" value="int"/>
     </eAnnotations>
-    <eAnnotations source="http://net.masagroup/soft/2019/GenGo">
-      <details key="instanceTypeName" value="int"/>
-    </eAnnotations>
   </eClassifiers>
   <eClassifiers xsi:type="ecore:EDataType" name="EBoolean" instanceClassName="boolean">
     <eAnnotations source="http:///org/eclipse/emf/ecore/util/ExtendedMetaData">
       <details key="baseType" value="http://www.w3.org/2001/XMLSchema#boolean"/>
     </eAnnotations>
     <eAnnotations source="http://net.masagroup/soft/2018/GenCpp">
-      <details key="instanceTypeName" value="bool"/>
-    </eAnnotations>
-    <eAnnotations source="http://net.masagroup/soft/2019/GenGo">
       <details key="instanceTypeName" value="bool"/>
     </eAnnotations>
   </eClassifiers>
@@ -800,9 +791,6 @@
     <eAnnotations source="http://net.masagroup/soft/2018/GenCpp">
       <details key="instanceTypeName" value="bool"/>
     </eAnnotations>
-    <eAnnotations source="http://net.masagroup/soft/2019/GenGo">
-      <details key="instanceTypeName" value="bool"/>
-    </eAnnotations>
   </eClassifiers>
   <eClassifiers xsi:type="ecore:EDataType" name="EByte" instanceClassName="byte">
     <eAnnotations source="http:///org/eclipse/emf/ecore/util/ExtendedMetaData">
@@ -811,9 +799,6 @@
     <eAnnotations source="http://net.masagroup/soft/2018/GenCpp">
       <details key="instanceTypeName" value="char"/>
     </eAnnotations>
-    <eAnnotations source="http://net.masagroup/soft/2019/GenGo">
-      <details key="instanceTypeName" value="byte"/>
-    </eAnnotations>
   </eClassifiers>
   <eClassifiers xsi:type="ecore:EDataType" name="EByteArray" instanceClassName="byte[]">
     <eAnnotations source="http:///org/eclipse/emf/ecore/util/ExtendedMetaData">
@@ -821,9 +806,6 @@
     </eAnnotations>
     <eAnnotations source="http://net.masagroup/soft/2018/GenCpp">
       <details key="instanceTypeName" value="char[]"/>
-    </eAnnotations>
-    <eAnnotations source="http://net.masagroup/soft/2019/GenGo">
-      <details key="instanceTypeName" value="[]byte"/>
     </eAnnotations>
   </eClassifiers>
   <eClassifiers xsi:type="ecore:EDataType" name="EByteObject" instanceClassName="java.lang.Byte">
@@ -834,16 +816,10 @@
     <eAnnotations source="http://net.masagroup/soft/2018/GenCpp">
       <details key="instanceTypeName" value="char"/>
     </eAnnotations>
-    <eAnnotations source="http://net.masagroup/soft/2019/GenGo">
-      <details key="instanceTypeName" value="byte"/>
-    </eAnnotations>
   </eClassifiers>
   <eClassifiers xsi:type="ecore:EDataType" name="EChar" instanceClassName="char">
     <eAnnotations source="http://net.masagroup/soft/2018/GenCpp">
       <details key="instanceTypeName" value="char"/>
-    </eAnnotations>
-    <eAnnotations source="http://net.masagroup/soft/2019/GenGo">
-      <details key="instanceTypeName" value="byte"/>
     </eAnnotations>
   </eClassifiers>
   <eClassifiers xsi:type="ecore:EDataType" name="ECharacterObject" instanceClassName="java.lang.Character">
@@ -854,34 +830,21 @@
     <eAnnotations source="http://net.masagroup/soft/2018/GenCpp">
       <details key="instanceTypeName" value="char"/>
     </eAnnotations>
-    <eAnnotations source="http://net.masagroup/soft/2019/GenGo">
-      <details key="instanceTypeName" value="byte"/>
-    </eAnnotations>
   </eClassifiers>
   <eClassifiers xsi:type="ecore:EDataType" name="EDate" instanceClassName="java.util.Date">
     <eAnnotations source="http://net.masagroup/soft/2018/GenCpp">
       <details key="instanceTypeName" value="std::time_t"/>
       <details key="include" value="&lt;ctime>"/>
     </eAnnotations>
-    <eAnnotations source="http://net.masagroup/soft/2019/GenGo">
-      <details key="instanceTypeName" value="time.Time"/>
-    </eAnnotations>
   </eClassifiers>
   <eClassifiers xsi:type="ecore:EDataType" name="EDiagnosticChain" instanceClassName="org.eclipse.emf.common.util.DiagnosticChain"
-      serializable="false">
-    <eAnnotations source="http://net.masagroup/soft/2019/GenGo">
-      <details key="instanceTypeName" value="ecore.EDiagnosticChain"/>
-    </eAnnotations>
-  </eClassifiers>
+      serializable="false"/>
   <eClassifiers xsi:type="ecore:EDataType" name="EDouble" instanceClassName="double">
     <eAnnotations source="http:///org/eclipse/emf/ecore/util/ExtendedMetaData">
       <details key="baseType" value="http://www.w3.org/2001/XMLSchema#double"/>
     </eAnnotations>
     <eAnnotations source="http://net.masagroup/soft/2018/GenCpp">
       <details key="instanceTypeName" value="double"/>
-    </eAnnotations>
-    <eAnnotations source="http://net.masagroup/soft/2019/GenGo">
-      <details key="instanceTypeName" value="float64"/>
     </eAnnotations>
   </eClassifiers>
   <eClassifiers xsi:type="ecore:EDataType" name="EDoubleObject" instanceClassName="java.lang.Double">
@@ -891,9 +854,6 @@
     </eAnnotations>
     <eAnnotations source="http://net.masagroup/soft/2018/GenCpp">
       <details key="instanceTypeName" value="double"/>
-    </eAnnotations>
-    <eAnnotations source="http://net.masagroup/soft/2019/GenGo">
-      <details key="instanceTypeName" value="float64"/>
     </eAnnotations>
   </eClassifiers>
   <eClassifiers xsi:type="ecore:EDataType" name="EEList" instanceClassName="org.eclipse.emf.common.util.EList"
@@ -917,9 +877,6 @@
     <eAnnotations source="http://net.masagroup/soft/2018/GenCpp">
       <details key="instanceTypeName" value="float"/>
     </eAnnotations>
-    <eAnnotations source="http://net.masagroup/soft/2019/GenGo">
-      <details key="instanceTypeName" value="float64"/>
-    </eAnnotations>
   </eClassifiers>
   <eClassifiers xsi:type="ecore:EDataType" name="EFloatObject" instanceClassName="java.lang.Float">
     <eAnnotations source="http:///org/eclipse/emf/ecore/util/ExtendedMetaData">
@@ -929,18 +886,12 @@
     <eAnnotations source="http://net.masagroup/soft/2018/GenCpp">
       <details key="instanceTypeName" value="float"/>
     </eAnnotations>
-    <eAnnotations source="http://net.masagroup/soft/2019/GenGo">
-      <details key="instanceTypeName" value="float64"/>
-    </eAnnotations>
   </eClassifiers>
   <eClassifiers xsi:type="ecore:EDataType" name="EInt" instanceClassName="int">
     <eAnnotations source="http:///org/eclipse/emf/ecore/util/ExtendedMetaData">
       <details key="baseType" value="http://www.w3.org/2001/XMLSchema#int"/>
     </eAnnotations>
     <eAnnotations source="http://net.masagroup/soft/2018/GenCpp">
-      <details key="instanceTypeName" value="int"/>
-    </eAnnotations>
-    <eAnnotations source="http://net.masagroup/soft/2019/GenGo">
       <details key="instanceTypeName" value="int"/>
     </eAnnotations>
   </eClassifiers>
@@ -952,17 +903,11 @@
     <eAnnotations source="http://net.masagroup/soft/2018/GenCpp">
       <details key="instanceTypeName" value="int"/>
     </eAnnotations>
-    <eAnnotations source="http://net.masagroup/soft/2019/GenGo">
-      <details key="instanceTypeName" value="int"/>
-    </eAnnotations>
   </eClassifiers>
   <eClassifiers xsi:type="ecore:EDataType" name="EJavaClass" instanceClassName="java.lang.Class">
     <eAnnotations source="http://net.masagroup/soft/2018/GenCpp">
       <details key="instanceTypeName" value="const std::type_info*"/>
       <details key="include" value="&lt;typeinfo>"/>
-    </eAnnotations>
-    <eAnnotations source="http://net.masagroup/soft/2019/GenGo">
-      <details key="instanceTypeName" value="reflect.Type"/>
     </eAnnotations>
     <eTypeParameters name="T"/>
   </eClassifiers>
@@ -971,9 +916,6 @@
       <details key="instanceTypeName" value="ecore::Any"/>
       <details key="include" value="&quot;ecore/Any.hpp&quot;"/>
     </eAnnotations>
-    <eAnnotations source="http://net.masagroup/soft/2019/GenGo">
-      <details key="instanceTypeName" value="interface{}"/>
-    </eAnnotations>
   </eClassifiers>
   <eClassifiers xsi:type="ecore:EDataType" name="ELong" instanceClassName="long">
     <eAnnotations source="http:///org/eclipse/emf/ecore/util/ExtendedMetaData">
@@ -981,9 +923,6 @@
     </eAnnotations>
     <eAnnotations source="http://net.masagroup/soft/2018/GenCpp">
       <details key="instanceTypeName" value="long"/>
-    </eAnnotations>
-    <eAnnotations source="http://net.masagroup/soft/2019/GenGo">
-      <details key="instanceTypeName" value="int"/>
     </eAnnotations>
   </eClassifiers>
   <eClassifiers xsi:type="ecore:EDataType" name="ELongObject" instanceClassName="java.lang.Long">
@@ -1004,9 +943,6 @@
       <details key="instanceTypeName" value="std::map"/>
       <details key="include" value="&lt;map>"/>
     </eAnnotations>
-    <eAnnotations source="http://net.masagroup/soft/2019/GenGo">
-      <details key="instanceTypeName" value="ecore.EMap"/>
-    </eAnnotations>
     <eTypeParameters name="K"/>
     <eTypeParameters name="V"/>
   </eClassifiers>
@@ -1016,25 +952,15 @@
       <details key="instanceTypeName" value="std::shared_ptr&lt;ecore::EResource>"/>
       <details key="include" value="&quot;ecore/EResource.hpp&quot;"/>
     </eAnnotations>
-    <eAnnotations source="http://net.masagroup/soft/2019/GenGo">
-      <details key="instanceTypeName" value="ecore.EResource"/>
-    </eAnnotations>
   </eClassifiers>
   <eClassifiers xsi:type="ecore:EDataType" name="EResourceSet" instanceClassName="org.eclipse.emf.ecore.resource.ResourceSet"
-      serializable="false">
-    <eAnnotations source="http://net.masagroup/soft/2019/GenGo">
-      <details key="instanceTypeName" value="ecore.EResourceSet"/>
-    </eAnnotations>
-  </eClassifiers>
+      serializable="false"/>
   <eClassifiers xsi:type="ecore:EDataType" name="EShort" instanceClassName="short">
     <eAnnotations source="http:///org/eclipse/emf/ecore/util/ExtendedMetaData">
       <details key="baseType" value="http://www.w3.org/2001/XMLSchema#short"/>
     </eAnnotations>
     <eAnnotations source="http://net.masagroup/soft/2018/GenCpp">
       <details key="instanceTypeName" value="short"/>
-    </eAnnotations>
-    <eAnnotations source="http://net.masagroup/soft/2019/GenGo">
-      <details key="instanceTypeName" value="uint16"/>
     </eAnnotations>
   </eClassifiers>
   <eClassifiers xsi:type="ecore:EDataType" name="EShortObject" instanceClassName="java.lang.Short">
@@ -1045,9 +971,6 @@
     <eAnnotations source="http://net.masagroup/soft/2018/GenCpp">
       <details key="instanceTypeName" value="short"/>
     </eAnnotations>
-    <eAnnotations source="http://net.masagroup/soft/2019/GenGo">
-      <details key="instanceTypeName" value="uint16"/>
-    </eAnnotations>
   </eClassifiers>
   <eClassifiers xsi:type="ecore:EDataType" name="EString" instanceClassName="java.lang.String">
     <eAnnotations source="http:///org/eclipse/emf/ecore/util/ExtendedMetaData">
@@ -1057,14 +980,8 @@
       <details key="instanceTypeName" value="std::string"/>
       <details key="include" value="&lt;string>"/>
     </eAnnotations>
-    <eAnnotations source="http://net.masagroup/soft/2019/GenGo">
-      <details key="instanceTypeName" value="string"/>
-    </eAnnotations>
   </eClassifiers>
   <eClassifiers xsi:type="ecore:EClass" name="EStringToStringMapEntry" instanceClassName="java.util.Map$Entry">
-    <eAnnotations source="http://net.masagroup/soft/2019/GenGo">
-      <details key="instanceTypeName" value="ecore.EMapEntry"/>
-    </eAnnotations>
     <eStructuralFeatures xsi:type="ecore:EAttribute" name="key" eType="#//EString">
       <eAnnotations source="http://net.masagroup/soft/2019/GenGo">
         <details key="getterName" value="GetStringKey"/>
@@ -1080,9 +997,6 @@
   </eClassifiers>
   <eClassifiers xsi:type="ecore:EDataType" name="ETreeIterator" instanceClassName="org.eclipse.emf.common.util.TreeIterator"
       serializable="false">
-    <eAnnotations source="http://net.masagroup/soft/2019/GenGo">
-      <details key="instanceTypeName" value="ecore.EIterator"/>
-    </eAnnotations>
     <eTypeParameters name="E"/>
   </eClassifiers>
   <eClassifiers xsi:type="ecore:EClass" name="EGenericType">

--- a/ecore.ecore
+++ b/ecore.ecore
@@ -920,7 +920,7 @@
     <eAnnotations source="http:///org/eclipse/emf/ecore/util/ExtendedMetaData">
       <details key="baseType" value="http://www.w3.org/2001/XMLSchema#long"/>
     </eAnnotations>
-    <eAnnotations source="http://net.masagroup/soft/2019/GenGo">
+    <eAnnotations source="http://net.masagroup/soft/2018/GenCpp">
       <details key="instanceTypeName" value="long"/>
     </eAnnotations>
   </eClassifiers>
@@ -929,13 +929,13 @@
       <details key="baseType" value="ELong"/>
       <details key="name" value="ELong:Object"/>
     </eAnnotations>
-    <eAnnotations source="http://net.masagroup/soft/2019/GenGo">
+    <eAnnotations source="http://net.masagroup/soft/2018/GenCpp">
       <details key="instanceTypeName" value="long"/>
     </eAnnotations>
   </eClassifiers>
   <eClassifiers xsi:type="ecore:EDataType" name="EMap" instanceClassName="java.util.Map"
       serializable="false">
-    <eAnnotations source="http://net.masagroup/soft/2019/GenGo">
+    <eAnnotations source="http://net.masagroup/soft/2018/GenCpp">
       <details key="instanceTypeName" value="std::map"/>
       <details key="include" value="&lt;map>"/>
     </eAnnotations>
@@ -944,7 +944,7 @@
   </eClassifiers>
   <eClassifiers xsi:type="ecore:EDataType" name="EResource" instanceClassName="org.eclipse.emf.ecore.resource.Resource"
       serializable="false">
-    <eAnnotations source="http://net.masagroup/soft/2019/GenGo">
+    <eAnnotations source="http://net.masagroup/soft/2018/GenCpp">
       <details key="instanceTypeName" value="std::shared_ptr&lt;ecore::EResource>"/>
       <details key="include" value="&quot;ecore/EResource.hpp&quot;"/>
     </eAnnotations>
@@ -978,8 +978,18 @@
     </eAnnotations>
   </eClassifiers>
   <eClassifiers xsi:type="ecore:EClass" name="EStringToStringMapEntry" instanceClassName="java.util.Map$Entry">
-    <eStructuralFeatures xsi:type="ecore:EAttribute" name="key" eType="#//EString"/>
-    <eStructuralFeatures xsi:type="ecore:EAttribute" name="value" eType="#//EString"/>
+    <eStructuralFeatures xsi:type="ecore:EAttribute" name="key" eType="#//EString">
+      <eAnnotations source="http://net.masagroup/soft/2019/GenGo">
+        <details key="getterName" value="GetStringKey"/>
+        <details key="setterName" value="SetStringKey"/>
+      </eAnnotations>
+    </eStructuralFeatures>
+    <eStructuralFeatures xsi:type="ecore:EAttribute" name="value" eType="#//EString">
+      <eAnnotations source="http://net.masagroup/soft/2019/GenGo">
+        <details key="getterName" value="GetStringValue"/>
+        <details key="setterName" value="SetStringValue"/>
+      </eAnnotations>
+    </eStructuralFeatures>
   </eClassifiers>
   <eClassifiers xsi:type="ecore:EDataType" name="ETreeIterator" instanceClassName="org.eclipse.emf.common.util.TreeIterator"
       serializable="false">

--- a/library.ecore
+++ b/library.ecore
@@ -68,7 +68,11 @@
     <eLiterals name="Biography" value="2"/>
   </eClassifiers>
   <eClassifiers xsi:type="ecore:EClass" name="Item" abstract="true">
-    <eStructuralFeatures xsi:type="ecore:EAttribute" name="publicationDate" eType="ecore:EDataType http://www.eclipse.org/emf/2002/Ecore#//EDate"/>
+    <eStructuralFeatures xsi:type="ecore:EAttribute" name="publicationDate" eType="ecore:EDataType http://www.eclipse.org/emf/2002/Ecore#//EDate">
+      <eAnnotations source="http:///org/eclipse/emf/ecore/util/ExtendedMetaData">
+        <details key="name" value="publication-date"/>
+      </eAnnotations>
+    </eStructuralFeatures>
   </eClassifiers>
   <eClassifiers xsi:type="ecore:EClass" name="Lendable" abstract="true" interface="true">
     <eStructuralFeatures xsi:type="ecore:EAttribute" name="copies" lowerBound="1"
@@ -80,12 +84,20 @@
   <eClassifiers xsi:type="ecore:EClass" name="Periodical" abstract="true" eSuperTypes="#//Item">
     <eStructuralFeatures xsi:type="ecore:EAttribute" name="title" eType="ecore:EDataType http://www.eclipse.org/emf/2002/Ecore#//EString"/>
     <eStructuralFeatures xsi:type="ecore:EAttribute" name="issuesPerYear" lowerBound="1"
-        eType="ecore:EDataType http://www.eclipse.org/emf/2002/Ecore#//EInt"/>
+        eType="ecore:EDataType http://www.eclipse.org/emf/2002/Ecore#//EInt">
+      <eAnnotations source="http:///org/eclipse/emf/ecore/util/ExtendedMetaData">
+        <details key="name" value="issues-per-year"/>
+      </eAnnotations>
+    </eStructuralFeatures>
   </eClassifiers>
   <eClassifiers xsi:type="ecore:EClass" name="AudioVisualItem" abstract="true" eSuperTypes="#//CirculatingItem">
     <eStructuralFeatures xsi:type="ecore:EAttribute" name="title" eType="ecore:EDataType http://www.eclipse.org/emf/2002/Ecore#//EString"/>
     <eStructuralFeatures xsi:type="ecore:EAttribute" name="minutesLength" lowerBound="1"
-        eType="ecore:EDataType http://www.eclipse.org/emf/2002/Ecore#//EInt"/>
+        eType="ecore:EDataType http://www.eclipse.org/emf/2002/Ecore#//EInt">
+      <eAnnotations source="http:///org/eclipse/emf/ecore/util/ExtendedMetaData">
+        <details key="name" value="minutes-length"/>
+      </eAnnotations>
+    </eStructuralFeatures>
     <eStructuralFeatures xsi:type="ecore:EAttribute" name="damaged" eType="ecore:EDataType http://www.eclipse.org/emf/2002/Ecore#//EBoolean"/>
   </eClassifiers>
   <eClassifiers xsi:type="ecore:EClass" name="BookOnTape" eSuperTypes="#//AudioVisualItem">
@@ -101,9 +113,17 @@
   </eClassifiers>
   <eClassifiers xsi:type="ecore:EClass" name="Person" eSuperTypes="#//Addressable">
     <eStructuralFeatures xsi:type="ecore:EAttribute" name="firstName" lowerBound="1"
-        eType="ecore:EDataType http://www.eclipse.org/emf/2002/Ecore#//EString"/>
+        eType="ecore:EDataType http://www.eclipse.org/emf/2002/Ecore#//EString">
+      <eAnnotations source="http:///org/eclipse/emf/ecore/util/ExtendedMetaData">
+        <details key="name" value="first-name"/>
+      </eAnnotations>
+    </eStructuralFeatures>
     <eStructuralFeatures xsi:type="ecore:EAttribute" name="lastName" lowerBound="1"
-        eType="ecore:EDataType http://www.eclipse.org/emf/2002/Ecore#//EString"/>
+        eType="ecore:EDataType http://www.eclipse.org/emf/2002/Ecore#//EString">
+      <eAnnotations source="http:///org/eclipse/emf/ecore/util/ExtendedMetaData">
+        <details key="name" value="last-name"/>
+      </eAnnotations>
+    </eStructuralFeatures>
   </eClassifiers>
   <eClassifiers xsi:type="ecore:EClass" name="Employee" eSuperTypes="#//Person">
     <eStructuralFeatures xsi:type="ecore:EReference" name="manager" eType="#//Employee"/>

--- a/library.ecore
+++ b/library.ecore
@@ -38,7 +38,13 @@
     <eStructuralFeatures xsi:type="ecore:EReference" name="branches" upperBound="-1"
         eType="#//Library" containment="true" eOpposite="#//Library/parentBranch"/>
     <eStructuralFeatures xsi:type="ecore:EReference" name="parentBranch" eType="#//Library"
-        eOpposite="#//Library/branches"/>
+        eOpposite="#//Library/branches">
+      <eAnnotations source="http:///org/eclipse/emf/ecore/util/ExtendedMetaData">
+        <details key="name" value="parent-branch"/>
+        <details key="kind" value="element"/>
+        <details key="namespace" value="##targetNamespace"/>
+      </eAnnotations>
+    </eStructuralFeatures>
     <eStructuralFeatures xsi:type="ecore:EAttribute" name="people" upperBound="-1"
         eType="ecore:EDataType http://www.eclipse.org/emf/2002/Ecore#//EFeatureMapEntry"
         transient="true">
@@ -71,6 +77,7 @@
     <eStructuralFeatures xsi:type="ecore:EAttribute" name="publicationDate" eType="ecore:EDataType http://www.eclipse.org/emf/2002/Ecore#//EDate">
       <eAnnotations source="http:///org/eclipse/emf/ecore/util/ExtendedMetaData">
         <details key="name" value="publication-date"/>
+        <details key="kind" value="attribute"/>
       </eAnnotations>
     </eStructuralFeatures>
   </eClassifiers>
@@ -87,6 +94,7 @@
         eType="ecore:EDataType http://www.eclipse.org/emf/2002/Ecore#//EInt">
       <eAnnotations source="http:///org/eclipse/emf/ecore/util/ExtendedMetaData">
         <details key="name" value="issues-per-year"/>
+        <details key="kind" value="attribute"/>
       </eAnnotations>
     </eStructuralFeatures>
   </eClassifiers>
@@ -96,6 +104,7 @@
         eType="ecore:EDataType http://www.eclipse.org/emf/2002/Ecore#//EInt">
       <eAnnotations source="http:///org/eclipse/emf/ecore/util/ExtendedMetaData">
         <details key="name" value="minutes-length"/>
+        <details key="kind" value="attribute"/>
       </eAnnotations>
     </eStructuralFeatures>
     <eStructuralFeatures xsi:type="ecore:EAttribute" name="damaged" eType="ecore:EDataType http://www.eclipse.org/emf/2002/Ecore#//EBoolean"/>
@@ -116,12 +125,14 @@
         eType="ecore:EDataType http://www.eclipse.org/emf/2002/Ecore#//EString">
       <eAnnotations source="http:///org/eclipse/emf/ecore/util/ExtendedMetaData">
         <details key="name" value="first-name"/>
+        <details key="kind" value="attribute"/>
       </eAnnotations>
     </eStructuralFeatures>
     <eStructuralFeatures xsi:type="ecore:EAttribute" name="lastName" lowerBound="1"
         eType="ecore:EDataType http://www.eclipse.org/emf/2002/Ecore#//EString">
       <eAnnotations source="http:///org/eclipse/emf/ecore/util/ExtendedMetaData">
         <details key="name" value="last-name"/>
+        <details key="kind" value="attribute"/>
       </eAnnotations>
     </eStructuralFeatures>
   </eClassifiers>
@@ -130,5 +141,12 @@
   </eClassifiers>
   <eClassifiers xsi:type="ecore:EClass" name="Addressable" abstract="true" interface="true">
     <eStructuralFeatures xsi:type="ecore:EAttribute" name="address" eType="ecore:EDataType http://www.eclipse.org/emf/2002/Ecore#//EString"/>
+  </eClassifiers>
+  <eClassifiers xsi:type="ecore:EClass" name="DocumentRoot">
+    <eAnnotations source="http:///org/eclipse/emf/ecore/util/ExtendedMetaData">
+      <details key="name" value=""/>
+    </eAnnotations>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="library" upperBound="-1"
+        eType="#//Library" containment="true"/>
   </eClassifiers>
 </ecore:EPackage>

--- a/library.ecore
+++ b/library.ecore
@@ -52,6 +52,14 @@
         <details key="kind" value="group"/>
       </eAnnotations>
     </eStructuralFeatures>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="ownerPdg" eType="#//Person"
+        containment="true">
+      <eAnnotations source="http:///org/eclipse/emf/ecore/util/ExtendedMetaData">
+        <details key="name" value="owner-pdg"/>
+        <details key="kind" value="element"/>
+        <details key="namespace" value="##targetNamespace"/>
+      </eAnnotations>
+    </eStructuralFeatures>
   </eClassifiers>
   <eClassifiers xsi:type="ecore:EClass" name="Writer" eSuperTypes="#//Person">
     <eAnnotations source="http://net.masagroup/soft/2018/GenCpp">
@@ -145,8 +153,31 @@
   <eClassifiers xsi:type="ecore:EClass" name="DocumentRoot">
     <eAnnotations source="http:///org/eclipse/emf/ecore/util/ExtendedMetaData">
       <details key="name" value=""/>
+      <details key="kind" value="mixed"/>
     </eAnnotations>
-    <eStructuralFeatures xsi:type="ecore:EReference" name="library" upperBound="-1"
-        eType="#//Library" containment="true"/>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="xMLNSPrefixMap" upperBound="-1"
+        eType="ecore:EClass http://www.eclipse.org/emf/2002/Ecore#//EStringToStringMapEntry"
+        transient="true" containment="true" resolveProxies="false">
+      <eAnnotations source="http:///org/eclipse/emf/ecore/util/ExtendedMetaData">
+        <details key="kind" value="attribute"/>
+        <details key="name" value="xmlns:prefix"/>
+      </eAnnotations>
+    </eStructuralFeatures>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="xSISchemaLocation" upperBound="-1"
+        eType="ecore:EClass http://www.eclipse.org/emf/2002/Ecore#//EStringToStringMapEntry"
+        transient="true" containment="true" resolveProxies="false">
+      <eAnnotations source="http:///org/eclipse/emf/ecore/util/ExtendedMetaData">
+        <details key="kind" value="attribute"/>
+        <details key="name" value="xsi:schemaLocation"/>
+      </eAnnotations>
+    </eStructuralFeatures>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="library" eType="#//Library"
+        containment="true">
+      <eAnnotations source="http:///org/eclipse/emf/ecore/util/ExtendedMetaData">
+        <details key="name" value="library"/>
+        <details key="kind" value="element"/>
+        <details key="namespace" value="##targetNamespace"/>
+      </eAnnotations>
+    </eStructuralFeatures>
   </eClassifiers>
 </ecore:EPackage>


### PR DESCRIPTION
Add xml mapping information via extendedmetadata annotations in library.ecore:

- documentroot added
- xml names like publication-date that are now came case compliant